### PR TITLE
Macros not being included in rails 5.0 controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.0.1
+* Fix macros inclusion in controllers by making use of ActiveSupport on_load hook
+
 ## v2.0.0
 * Add support for rails 5.1
 * Lose support for rails 3.2

--- a/lib/rename_params/macros.rb
+++ b/lib/rename_params/macros.rb
@@ -14,5 +14,6 @@ module RenameParams
   end
 end
 
-ActionController::API.send(:include, RenameParams::Macros) if defined?(ActionController::API)
-ActionController::Base.send(:include, RenameParams::Macros) if defined?(ActionController::Base)
+ActiveSupport.on_load :action_controller do
+  include RenameParams::Macros
+end

--- a/lib/rename_params/version.rb
+++ b/lib/rename_params/version.rb
@@ -1,3 +1,3 @@
 module RenameParams
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 end


### PR DESCRIPTION
These changes make use of `ActiveSupport.on_load :action_controller` hook to include the macros in the controllers.